### PR TITLE
Now entityindex is can use custom template too

### DIFF
--- a/.versions
+++ b/.versions
@@ -37,7 +37,7 @@ jquery@1.11.3_2
 json@1.0.3
 launch-screen@1.0.2
 livedata@1.0.13
-local-test:orionjs:core@0.7.2
+local-test:orionjs:core@0.7.5
 localstorage@1.0.3
 logging@1.0.7
 manuelschoebel:ms-seo@0.4.1
@@ -55,7 +55,7 @@ mongo-livedata@1.0.8
 npm-bcrypt@0.7.8_2
 observe-sequence@1.0.6
 ordered-dict@1.0.3
-orionjs:core@0.7.2
+orionjs:core@0.7.5
 random@1.0.3
 reactive-dict@1.1.0
 reactive-var@1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ Orion Core
 
 This is the changelog for ```orionjs:core```.
 
+### 0.7.5
+
+- Choose fields for custom entity permissions.
+
+### 0.7.4
+
+- Entity index table doesn't listen to click if it is <a> or <button>
+
+### 0.7.3
+
+- In /login you can set ?redirect=xxx.
+
 ### 0.7.2
 
 - "Created by" on entities is no more required (to insert values on server).

--- a/admin/client-common/entities.js
+++ b/admin/client-common/entities.js
@@ -10,6 +10,38 @@ AutoForm.hooks({
 	}
 });
 
+orion.admin.entitiesCreateDefaultHelpers = {
+	getFields: function() {
+		var entity = Router.current().data().entity;
+		var item = Router.current().data().item;
+		if (entity) {
+			if (!Meteor.userId()) {
+				return;
+			}
+
+			var user = Meteor.users.findOne(Meteor.userId());
+
+			if (user.hasPermission('entity.' + entity.name + '.all')) {
+				return;
+			}
+
+			if (user.hasPermission('entity.' + entity.name + '.personal')) {
+				return;
+			}
+
+			for (var i = 0; i < entity.customPermissions.length; i++) {
+				var permission = entity.customPermissions[i];
+				if (user.hasPermission('entity.' + entity.name + '.' + permission.name)) {
+					if (permission.fields) {
+						return permission.fields(Meteor.userId());
+					}
+				}
+			}
+		}
+		return;
+	}
+}
+
 /**
  * adminEntitiesDelete
  */
@@ -25,8 +57,11 @@ orion.admin.entitiesDeleteHelpers = {
 /**
  * adminEntitiesIndex
  */
-orion.admin.entitiesIndexEvents = {
+orion.admin.entitiesIndexDefaultEvents = {
 	'click tr': function(event) {
+		if ($(event.target).is('a') || $(event.target).is('button')) {
+			return;
+		}
 		var dataTable = $(event.target).closest('table').DataTable();
 		var rowData = dataTable.row(event.currentTarget).data();
 		if (rowData) {
@@ -38,8 +73,7 @@ orion.admin.entitiesIndexEvents = {
 	}
 }
 
-
-orion.admin.entitiesIndexHelpers = {
+orion.admin.entitiesIndexDefaultHelpers = {
 	table: function() {
 		if (this.entity) {
 			return this.entity.table;
@@ -76,7 +110,7 @@ orion.admin.entitiesIndexHelpers = {
 	}
 }
 
-orion.admin.entitiesIndexRendered = function() {
+orion.admin.entitiesIndexDefaultRendered = function() {
 	Session.set('adminEntitiesIndexShowTable', true);
 
 	var toogleTable = function() {
@@ -104,7 +138,6 @@ AutoForm.hooks({
 	}
 });
 
-// defualts when no custom template
 orion.admin.entitiesUpdateDefaultEvents = {
 	'click #submit-btn': function() {
 		$("#updateEntityForm").submit();
@@ -114,6 +147,35 @@ orion.admin.entitiesUpdateDefaultEvents = {
 orion.admin.entitiesUpdateDefaultHelpers = {
 	getEntity: function () {
 		return Router.current().data().entity.name;
+	},
+	getFields: function() {
+		var entity = Router.current().data().entity;
+		var item = Router.current().data().item;
+		if (entity) {
+			if (!Meteor.userId()) {
+				return;
+			}
+
+			var user = Meteor.users.findOne(Meteor.userId());
+
+			if (user.hasPermission('entity.' + entity.name + '.all')) {
+				return;
+			}
+
+			if (user.hasPermission('entity.' + entity.name + '.personal')) {
+				return;
+			}
+
+			for (var i = 0; i < entity.customPermissions.length; i++) {
+				var permission = entity.customPermissions[i];
+				if (user.hasPermission('entity.' + entity.name + '.' + permission.name)) {
+					if (permission.fields) {
+						return permission.fields(Meteor.userId());
+					}
+				}
+			}
+		}
+		return;
 	},
 	canUpdateEntity: function() {
 		var entity = Router.current().data().entity;

--- a/admin/routes.js
+++ b/admin/routes.js
@@ -39,7 +39,7 @@ orion.RouteController = RouteController.extend({
 });
 
 /**
- * The home route for the admin, redirects to
+ * The home route for the admin, redirects to 
  * dictionaryUpdate or create account.
  */
 Router.route('/admin', {
@@ -80,7 +80,7 @@ Router.route('/admin/create-account/:_id', {
  */
 Router.route('/admin/dictionary/:category?', {
 	name: 'adminDictionaryUpdate',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: function() {
 		if (!orion.dictionary.isActive()) {
 			this.redirect('atChangePwd')
@@ -108,7 +108,7 @@ Router.route('/admin/dictionary/:category?', {
  */
 Router.route('/admin/users', {
 	name: 'adminUsersIndex',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: orion.users.ensureRoutePermissions('admin'),
 	data: function() {
 		return Meteor.users.find();
@@ -120,7 +120,7 @@ Router.route('/admin/users', {
  */
 Router.route('/admin/users/invite', {
 	name: 'adminUsersCreate',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: orion.users.ensureRoutePermissions('admin')
 });
 
@@ -129,8 +129,8 @@ Router.route('/admin/users/invite', {
  */
 Router.route('/admin/users/:_id/edit', {
 	name: 'adminUsersEdit',
-	controller: orion.RouteController,
-	onBeforeAction: orion.users.ensureRoutePermissions('admin'),
+	controller: orion.RouteController,  
+	onBeforeAction: orion.users.ensureRoutePermissions('admin'), 
 	data: function() {
 		return Meteor.users.findOne(this.params._id);
 	}
@@ -141,8 +141,8 @@ Router.route('/admin/users/:_id/edit', {
  */
 Router.route('/admin/users/:_id/delete', {
 	name: 'adminUsersDelete',
-	controller: orion.RouteController,
-	onBeforeAction: orion.users.ensureRoutePermissions('admin'),
+	controller: orion.RouteController,  
+	onBeforeAction: orion.users.ensureRoutePermissions('admin'), 
 	data: function() {
 		return Meteor.users.findOne(this.params._id);
 	}
@@ -154,7 +154,7 @@ Router.route('/admin/users/:_id/delete', {
  */
 Router.route('/admin/config/:configCategory?', {
 	name: 'adminConfigUpdate',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: orion.users.ensureRoutePermissions('admin'),
 	data: function() {
 		if (this.params.configCategory) {
@@ -176,7 +176,7 @@ Router.route('/admin/config/:configCategory?', {
  */
 Router.route('/admin/e/:entity/', {
 	name: 'adminEntitiesIndex',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: function() {
 		return orion.users.ensureRoutePermissions('entity.' + this.params.entity)(this);
 	},
@@ -192,7 +192,7 @@ Router.route('/admin/e/:entity/', {
  */
 Router.route('/admin/e/:entity/create', {
 	name: 'adminEntitiesCreate',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: function() {
 		return orion.users.ensureRoutePermissions('entity.' + this.params.entity)(this);
 	},
@@ -208,7 +208,7 @@ Router.route('/admin/e/:entity/create', {
  */
 Router.route('/admin/e/:entity/:_id/update', {
 	name: 'adminEntitiesUpdate',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: function() {
 		return orion.users.ensureRoutePermissions('entity.' + this.params.entity)(this);
 	},
@@ -229,7 +229,7 @@ Router.route('/admin/e/:entity/:_id/update', {
  */
 Router.route('/admin/e/:entity/:_id/delete', {
 	name: 'adminEntitiesDelete',
-	controller: orion.RouteController,
+	controller: orion.RouteController,  
 	onBeforeAction: function() {
 		return orion.users.ensureRoutePermissions('entity.' + this.params.entity)(this);
 	},

--- a/entities/common.js
+++ b/entities/common.js
@@ -164,7 +164,7 @@ orion.getNewEntityOptions = function(name, options) {
 		singularName: name,
 		createTemplate:'adminEntitiesCreateDefault',
 		indexTemplate:'adminEntitiesIndexDefault',
-+   updateTemplate:'adminEntitiesUpdateDefault',
+	  updateTemplate:'adminEntitiesUpdateDefault',
 		tableColumns: [{data: '_id', title: 'ID'}],
 		extraFields: [],
 	}, options);

--- a/entities/common.js
+++ b/entities/common.js
@@ -88,6 +88,14 @@ orion.getEntityDefaultAllowPermissions = function(entity) {
 			for (var i = 0; i < entity.customPermissions.length; i++) {
 				var permission = entity.customPermissions[i];
 				if (user.hasPermission('entity.' + entity.name + '.' + permission.name)) {
+					if (permission.fields) {
+						var allowedFields = permission.fields(userId);
+						var keys = _.keys(doc)
+						var diff = _.difference(keys, allowedFields, ['createdAt', 'createdBy']);
+						if (diff.length > 0) {
+							return false;
+						}
+					}
 					return permission.create(userId, doc) && doc.createdBy === userId;
 				}
 			}
@@ -111,6 +119,14 @@ orion.getEntityDefaultAllowPermissions = function(entity) {
 			for (var i = 0; i < entity.customPermissions.length; i++) {
 				var permission = entity.customPermissions[i];
 				if (user.hasPermission('entity.' + entity.name + '.' + permission.name)) {
+					if (permission.fields) {
+						var allowedFields = permission.fields(userId);
+						var keys = fields;
+						var diff = _.difference(keys, allowedFields, ['updatedAt']);
+						if (diff.length > 0) {
+							return false;
+						}
+					}
 					return permission.update(userId, doc, fields, modifier);
 				}
 			}
@@ -146,9 +162,9 @@ orion.getNewEntityOptions = function(name, options) {
 		icon: 'pencil',
 		pluralName: name,
 		singularName: name,
-		customTypeForm:false,
-  	createTemplate:'adminEntitiesCreateDefault',
-		updateTemplate:'adminEntitiesUpdateDefault',
+		createTemplate:'adminEntitiesCreateDefault',
+		indexTemplate:'adminEntitiesIndexDefault',
++   updateTemplate:'adminEntitiesUpdateDefault',
 		tableColumns: [{data: '_id', title: 'ID'}],
 		extraFields: [],
 	}, options);

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
 	name: 'orionjs:core',
 	summary: 'Simple and powerful admin panel for meteor',
-	version: '0.7.2',
+	version: '0.7.5',
 	git: 'https://github.com/orionjs/core'
 });
 
@@ -12,16 +12,16 @@ Package.onUse(function(api) {
 		'meteor-platform',
 		'meteorhacks:subs-manager@1.1.0',
 		'accounts-base',
-		'accounts-password',
-		'dburles:collection-helpers@1.0.2',
+		'accounts-password', 
+		'dburles:collection-helpers@1.0.2', 
 		'aldeed:collection2@2.0.0',
-		'aldeed:tabular@1.1.0',
+		'aldeed:tabular@1.1.0',  
 		'meteorhacks:inject-initial@1.0.2',
-		'aldeed:autoform@5.1.1',
+		'aldeed:autoform@5.1.1', 
 		'matb33:collection-hooks@0.7.7',
-		'iron:router@1.0.7',
-		'zimme:iron-router-active@1.0.0',
-		'aldeed:delete-button@1.0.0',
+		'iron:router@1.0.7', 
+		'zimme:iron-router-active@1.0.0', 
+		'aldeed:delete-button@1.0.0', 
 		'useraccounts:core@1.8.1',
 		'manuelschoebel:ms-seo@0.4.1',
 		]);
@@ -30,8 +30,8 @@ Package.onUse(function(api) {
 		'accounts-base',
 		'accounts-password',
 		'dburles:collection-helpers',
-		'aldeed:collection2',
-		'aldeed:autoform',
+		'aldeed:collection2', 
+		'aldeed:autoform', 
 		'aldeed:tabular',
 		'matb33:collection-hooks',
 		'iron:router',
@@ -48,7 +48,7 @@ Package.onUse(function(api) {
 		'users/accounts-templates.js',
 		'attributes/common.js',
 		'dictionary/common.js',
-		'entities/common.js',
+		'entities/common.js', 
 		'api/main.js',
 		'admin/routes.js',
 		]);

--- a/users/README.md
+++ b/users/README.md
@@ -158,6 +158,9 @@ in that case, ```doc``` will be ```undefined```.
 - ```remove``` **Function**. Input ```userId```, ```doc```.
 Return ```true``` or ```false```.
 
+- ```fields``` **Function**. Input ```userId```.
+Return a ```array``` of fields that the user can edit. If this is not set, the user can edit all fields.
+
 Example:
 
 ```js

--- a/users/accounts-templates.js
+++ b/users/accounts-templates.js
@@ -25,6 +25,11 @@ AccountsTemplates.configureRoute('changePwd', {
 AccountsTemplates.configureRoute('signIn', {
 	template: 'adminAccountsLogin',
 	path: '/login',
+    name: 'login',
+    redirect: function() {
+        var url = Router.current().params.query.redirect || '/admin';
+        Router.go(url);
+    }
 });
 
 /**

--- a/users/common.js
+++ b/users/common.js
@@ -27,7 +27,8 @@ orion.users.permissions.createCustomEntityPermission = function(options) {
 		indexFilter: Match.Any,
 		update: Match.Any,
 		create: Match.Any,
-		remove: Match.Any
+		remove: Match.Any,
+		fields: Match.Optional(Match.Any),
 	});
 
 	orion.entities[options.entity].customPermissions.push(options);


### PR DESCRIPTION
cloned core master and added feature for index. If it complains of conflicts ignore, next time I will just add upstream to my forks instead of re-cloning. Please accept the PR asap or boostrap will complain about no template for ```adminEntitiesIndexDefault```